### PR TITLE
Clarify claiming a namespace

### DIFF
--- a/jekyll/_cci2/creating-orbs.md
+++ b/jekyll/_cci2/creating-orbs.md
@@ -17,6 +17,7 @@ The following high-level steps will enable you to publish your first orb:
 
 1. Claim a namespace (assuming you don't yet have one), eg:
 `circleci namespace create sandbox github CircleCI-Public`
+In this example we are creating the `sandbox` namespace tied to the github organization `CircleCI-Public`.
 
 **Note** Namespaces cannot be removed or renamed once you have claimed a namespace.
 


### PR DESCRIPTION
I'm new to the process of creating orbs. While going through the docs, I came across the `circleci namespace create` command and found the parameters confusing. After a while of digging, I found that I could run `circleci namespace create --help` to understand what the params meant. It would have been easier if there was something right there in the documentation that gave a short explanation.